### PR TITLE
Updated token validation for new GitHub format

### DIFF
--- a/bin/github_issue_stats
+++ b/bin/github_issue_stats
@@ -86,7 +86,7 @@ Commander.configure do
       options.labels = Array(options.labels)
 
       raise ArgumentError.new("--token is required") if options.token.nil?
-      raise ArgumentError.new("invalid --token format") unless /\A\h{40}\z/.match(options.token)
+      raise ArgumentError.new("invalid --token format") unless /\Agh(p|o|u|s|r)_[A-Za-z0-9]+\z/.match(options.token)
       raise ArgumentError.new("--scopes is required") if options.scopes.nil?
       raise ArgumentError.new("invalid --interval_length format") unless /\A\d[hdwmy]\z/.match(options.interval_length)
       raise ArgumentError.new("invalid --interval_count format") if options.interval_count.nil? || options.interval_count < 1


### PR DESCRIPTION
GitHub have [updated their authentication token format](https://github.blog/changelog/2021-03-31-authentication-token-format-updates-are-generally-available/) - this updates the `--token` validation to support the new format.